### PR TITLE
Styling tweaks

### DIFF
--- a/layouts/talks/li.html
+++ b/layouts/talks/li.html
@@ -1,5 +1,4 @@
-<div class="talks">
-  <a href="/talks/{{ .Slug }}"><img src="/img/{{ .Slug }}.png" class="thumbnail" alt="{{ .Title }}"></a>
+<a class="talk" href="/talks/{{ .Slug }}"><img src="/img/{{ .Slug }}.png" class="thumbnail" alt="{{ .Title }}">
 
   <h3>{{ .Title }}</h3>
 
@@ -10,4 +9,4 @@
   <p class="dates">
     {{ .Date.Format "January 2006"}}
   </p>
-</div>
+</a>

--- a/layouts/talks/single.html
+++ b/layouts/talks/single.html
@@ -8,12 +8,14 @@
           <iframe width="490" height="275.63" src="{{ . }}" frameborder="0" allowfullscreen class="videos"></iframe>
           {{ end }}
 
-          <h2>{{ .Title }}</h2>
+          <h2 class="talk-heading">{{ .Title }}</h2>
           <p class="talk-dates">
             {{ .Date.Format "January 2006"}}
           </p>
 
+          <div class="talk-synopsis">
           {{ .Content }}
+          </div>
 
         </section>
 

--- a/static/css/minimistic.css
+++ b/static/css/minimistic.css
@@ -104,16 +104,25 @@ li {
   line-height: 25px;
 }
 
+.talk-heading {
+  padding-bottom:10px;
+}
 .talk-dates {
   font-size: 13px;
   font-weight: 300;
   color: grey;
   text-align: center;
   line-height: 20px;
-  padding-bottom: 20px;
+  padding-bottom: 30px;
 }
-.quotes {
-  font-style: italic;
+.talk-synopsis {
+  color:#333;
+  font-size:14px;
+  line-height:21px;
+  font-weight:300;
+}
+.talk-synopsis p {
+  padding-bottom:15px;
 }
 .thumbnail {
   width: 150px;

--- a/static/css/minimistic.css
+++ b/static/css/minimistic.css
@@ -103,24 +103,7 @@ li {
   color: #333333;
   line-height: 25px;
 }
-.video-text {
-  font-size: 13px;
-  font-weight: 300;
-  color: #333333;
-  line-height: 20px;
-  float: right;
-  width: 326.67px;
-  padding-bottom: 20px;
-}
-.dates {
-  font-size: 11px;
-  font-weight: 300;
-  color: grey;
-  line-height: 20px;
-  float: right;
-  width: 326.67px;
-  padding-bottom: 20px;
-}
+
 .talk-dates {
   font-size: 13px;
   font-weight: 300;
@@ -130,15 +113,57 @@ li {
   padding-bottom: 20px;
 }
 .quotes {
-  font-style: italic; 
+  font-style: italic;
 }
 .thumbnail {
   width: 150px;
   float: left;
 }
-.talks {
-  display: table;
+.talk {
+  position:relative;
+  overflow:hidden;
+  text-decoration:none;
+  display:block;
+  padding-bottom:30px;
 }
+.talk+.talk {
+  padding-top:30px;
+}
+.talk+.talk:before {
+  position:absolute;
+  top:0;
+  left:15%;
+  right:15%;
+  height:1px;
+  background:#eee;
+  content: "";
+}
+.talk h3 {
+  color:#333;
+  font-size:17px;
+  line-height:21px;
+  margin-bottom:10px;
+  padding-bottom:0;
+}
+.talk h3,
+.talk p {
+  margin-left:170px;
+}
+.talk .video-text {
+  font-size: 14px;
+  font-weight: 300;
+  color: #333;
+  line-height: 20px;
+  padding-bottom:0;
+  margin-bottom: 10px;
+}
+.talk .dates {
+  font-size: 11px;
+  font-weight: 300;
+  color: #aaa;
+  padding-bottom:0;
+}
+
 footer {
   padding-top: 100px;
   padding-bottom: 100px;


### PR DESCRIPTION
I've made two commits. The first is to the list of talks page, the second to the individual talk page. 

Starting with the second commit, I've just tweaked the spacing and text-style slightly, before and after:

<img width="539" alt="screen shot 2017-07-26 at 00 55 15" src="https://user-images.githubusercontent.com/286476/28598667-08fdd0b8-719d-11e7-8b0a-0ba6e803731a.png">
<img width="542" alt="screen shot 2017-07-26 at 00 52 16" src="https://user-images.githubusercontent.com/286476/28598659-fce1d43c-719c-11e7-9f9d-3a3d6c653103.png">

The first commit is a bit more complicated in terms of code changes. Here's the before and after:

<img width="661" alt="screen shot 2017-07-26 at 00 01 40" src="https://user-images.githubusercontent.com/286476/28598973-0db72bca-719f-11e7-8319-3e95796934bf.png">

<img width="594" alt="screen shot 2017-07-26 at 01 10 36" src="https://user-images.githubusercontent.com/286476/28599004-314a170a-719f-11e7-9afd-27005c756760.png">

In the HTML, I've done two things:
1) Rename the `talks` class to `talk`. In CSS, classes are normally used as reusable bits of html. As this is a bit of html about a `talk`, the normal thing would be to have it singuarlised. If it was a reusable bit of html about multiple talks, then you would use plural. If I was to refactor the site further I would add an `id` to the div that wraps all of these `talk`s of `talk`, to give: 

```
<div id="talks">
  <div class="talk">...</div>
  <div class="talk">...</div>
  <div class="talk">...</div>
</div>
```

2) I've then changed the outer `talk` div to be an `a` instead. So the whole thing (image and text) becomes a link to the talk. I find it confusing when I'm reading a title on a website but to go to that thing I have to somehow know to click the image next to it. While this is a common thing you see, I feel it's very unintuitive UI. Making the whole thing clickable fixes that.

There's a couple of things in the CSS:
- I've wrapped each sub-component in the outer component. So the `dates` div here is now `.talk .dates`. That just gives you safety that affecting something somewhere in the site won't have side effects. It's encapsulation.

- On the `talk`, I've added three things of note:
  - `display:block`. Because talk is now an `a` tag, and `a` tags are inline elements by default (ie they flow with the page), I needed to add this to make the `a` act as a box, not just text.
  - `overflow:hidden`. The `talk` has the image `float:left`ing inside it. `overflow:hidden` encapsulates floats to the div that they're in. (It's best not to ask why this is the case :))
  - `position:relative`. I'm using a little cheat to add the new line above the `talk`. By saying the div has a relative position on the page, I can then position other things arbitrarily inside it (which I do next with the line in between)

- `.talk+.talk:before` - This is probably the only actually confusing bit I've added. This means, when there are two `talk`s next to each other, add a pseudo element before the second. I then go on to make this element 1px tall, starting 15% from the left and going 15% from the right, with a light background. This gives you a neat line between the two talks that sits 70% of the way in the centre.

I think the rest should make sense. The number one quick thing that made the biggest difference was making your line-spacing was sufficient. There are people who studying typography who have amazing rules about line-spacing by 1.4x normally works as a guide for me.

Hope that's helpful. If you hate anything I've done, I won't be in the slightest bit offended if you don't merge, or change it up first :) It's been fun learning hugo!
